### PR TITLE
Use fog-core ~> 2.1

### DIFF
--- a/fog-opennebula.gemspec
+++ b/fog-opennebula.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
     ###### Gem dependencies ######
 
-    s.add_dependency 'fog-core',  '= 2.1.0'
+    s.add_dependency 'fog-core',  '~> 2.1'
     s.add_dependency 'fog-json',  '~> 1.1'
     s.add_dependency 'fog-xml',   '~> 0.1'
     s.add_dependency 'nokogiri',  '< 1.13' if RUBY_VERSION < '2.6.0'


### PR DESCRIPTION
Hello! We try to use this module with foreman 3.5 but there is a dependency conflict. Foreman requires fog-core ~> 2.1, but fog-opennebula requires fog-core = 2.1.0 so it can not be installed. Can we make this dependency not such strict? I don't think the minor version does matter.