### PR TITLE
Address possible dependency issues

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+---
+name: release
+
+"on":
+  push:
+    branches: [main]
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: ruby
+          package-name: fog-opennebula
+          version-file: lib/fog/opennebula/version.rb
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Build and publish to GitHub Package
+        uses: actionshub/publish-gem-to-github@main
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: ${{ secrets.OWNER }}
+
+      - name: Build and publish to RubyGems
+        uses: actionshub/publish-gem-to-rubygems@main
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          token: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,16 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 group :development, :test do
-  # This is here because gemspec doesn't support require: false
-  #gem "netrc", :require => false
-  #gem "octokit", :require => false
+    # Existing gems
+    # gem "netrc", :require => false
+    # gem "octokit", :require => false
+
+    gem 'minitest'
+    gem 'minitest-stub-const'
+    gem 'mocha'
+    gem 'rake'
+    gem 'shindo'
+    gem 'simplecov'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Interaction with [OpenNebula](http://www.opennebula.org) is done via the [Ruby O
 
 ## Requirements
 
-- Ruby version 2.0.x and higher
-- gems: See [gemspec](./fog-opennebula.gemspec)
-- Working OpenNebula instance with XML-RPC and user credentials
+- See [gemspec](./fog-opennebula.gemspec) for ruby and gem versions
+- User credentials for an XMLRPC endpoint of an OpenNebula instance
 
 ## Installation
 

--- a/fog-opennebula.gemspec
+++ b/fog-opennebula.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fog/opennebula/version'
 
 Gem::Specification.new do |s|
-    s.name = 'fog-opennebula'
+    s.name        = 'fog-opennebula'
     s.version     = Fog::OpenNebula::VERSION
     s.authors     = ['Daniel Clavijo Coca']
     s.email       = 'dclavijo@opennebula.systems'
@@ -14,23 +14,15 @@ Gem::Specification.new do |s|
 
     s.files         = `git ls-files -z`.split("\x0")
     s.executables   = s.files.grep(%r{^bin/}) {|f| File.basename(f) }
-    s.test_files    = s.files.grep(%r{^(test|spec|features)/})
     s.require_paths = ['lib']
 
-    s.required_ruby_version = '>= 2.0.0'
+    s.required_ruby_version = '>= 2.7.0'
 
     ###### Gem dependencies ######
 
-    s.add_dependency 'fog-core',  '~> 2.1'
-    s.add_dependency 'fog-json',  '~> 1.1'
-    s.add_dependency 'fog-xml',   '~> 0.1'
-    s.add_dependency 'nokogiri',  '< 1.13' if RUBY_VERSION < '2.6.0'
+    s.add_dependency 'fog-core', '~> 2.1'
+    s.add_dependency 'fog-json', '~> 1.1'
+    s.add_dependency 'fog-xml', '~> 0.1'
     s.add_dependency 'opennebula'
-    s.add_dependency 'xmlrpc', '~> 0.3.0' if RUBY_VERSION > '2.4.0'
-    s.add_development_dependency 'minitest'
-    s.add_development_dependency 'minitest-stub-const'
-    s.add_development_dependency 'mocha', '~> 1.1.0'
-    s.add_development_dependency 'rake'
-    s.add_development_dependency 'shindo', '~> 0.3.4'
-    s.add_development_dependency 'simplecov'
+    s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/fog/opennebula/version.rb
+++ b/lib/fog/opennebula/version.rb
@@ -2,7 +2,7 @@ module Fog
 
     module OpenNebula
 
-        VERSION = '0.0.4'.freeze
+        VERSION = '0.0.5'.freeze
 
     end
 


### PR DESCRIPTION
- Gemfiles have been improved to leave most of the dependency management to the opennebula gem, except for the fog specific dependencies.
- Gem publishing automation with github actions